### PR TITLE
README usage correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ pip install yahoo_quote_download
 ## Data Download
 The main entry point is a commandline application. To download EOD data for a ticker, please try
 <pre><code>
-yqdownload -t ticker -f datafile [-s startdate] [-e enddate] [-m maxretries] [-v verbose] [-h]
+yqdownload -t ticker -f datafile [-b begindate] [-e enddate] [-m maxretries] [-v verbose] [-h]
 </code></pre>
 where
 * ticker - (Required) the ticker to download, e.g., MSFT (Microsoft) or ^DJI (Dow Jones Industrial index). Please check Yahoo financial webpage for the tickers they use.
 * datafile - (Required) the file where the downloaded data is saved to.
-* startdate - (Optional) the starting and ending date of the download in the format of YYYY-MM-DD. If not provided, the data will be incrementally downloaded based on the data in the data file. If all fails, the default is 1970-01-01.
-* enddate - (Optional) the starting and ending date of the download in the format of YYYY-MM-DD. If not provided, the default is the current day.
+* begindate - (Optional) the starting date of the download in the format of YYYY-MM-DD. If not provided, the data will be incrementally downloaded based on the data in the data file. If all fails, the default is 1970-01-01.
+* enddate - (Optional) the ending date of the download in the format of YYYY-MM-DD. If not provided, the default is the current day.
 * maxretries - (Optional) max number of retries. Occationally, the download will reach an error. This is the maximum number of retries in such cases. The default is 5.
 * verbose - (Optional) verbose level. The default is 1. You may use 0 to make it really quiet.
 * As usual, you may use -h or --help options to see all the supported options.


### PR DESCRIPTION
Fix some minor readme corrections:

- `-b begindate` instead of `-s startdate` - since this is the current usage pattern
- clarify description for each of the date parameters - for some reason, they each talked about both.